### PR TITLE
Issue 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ This package maintains a notes file in the file specified by *filetree-notes-fil
 
 Local project specific notes files can also be used--simply create an empty file in the project directory with the name "*filetree-notes-local.org*" (or whatever name is set by the variable *filetree-relative-notes-filename*).  Files under this directory will use this file for notes instead of the main file.  The file links in the local file will be relative to the project directory.  The main org-mode file will still be used for files without a local org-mode file.
 
-In order to go to the entry for a file (and create an entry if it doesn't exist from a file buffers), use the `filetree-toggle-info-buffer` command.  For example, you can use the following key binding in your .emacs to run the command:
+In order to toggle the info buffer use the `filetree-toggle-info-buffer` command.  If called from a file buffer, this command will create a new entry if it doesn't already exist.  You can create a keybinding in your `.emacs` to run the command, e.g.,:
 ```
 (global-set-key (kbd "C-c <return>") (lambda ()
                                        "Toggle filetree-info-buffer and switch to it if active"
@@ -223,7 +223,7 @@ In order to go to the entry for a file (and create an entry if it doesn't exist 
 ```
 The same command will open and close (after saving) the notes buffer in the side window.
 
-To create a new note from the file at point in the *filetree* buffer or a *dired* buffer, use the command `filetree-create-note`.  If you would like to have the notes update as you navigate through *dired* buffers (as they do in the *filetree* buffer), you can add the following advice call in your `.emacs`:
+To create a new note from the file at point in the *filetree* buffer, a *dired* buffer or a file buffer, use the command `filetree-create-note`.  If you would like to have the notes update as you navigate through *dired* buffers (as they do in the *filetree* buffer), you can add the following advice call in your `.emacs`:
 ```
 (advice-add 'dired-next-line :after
             (lambda (&rest args)

--- a/README.md
+++ b/README.md
@@ -226,9 +226,7 @@ The same command will open and close (after saving) the notes buffer in the side
 To create a new note from the file at point in the *filetree* buffer, a *dired* buffer or a file buffer, use the command `filetree-create-note`.  If you would like to have the notes update as you navigate through *dired* buffers (as they do in the *filetree* buffer), you can add the following advice call in your `.emacs`:
 ```
 (advice-add 'dired-next-line :after
-            (lambda (&rest args)
-              (filetree-update-info-buffer
-               (file-truename (dired-get-file-for-visit)))))
+            (lambda (&rest args) (filetree-update-info-buffer)))
 ```
 
 Within the *filetree* buffer, the *i* key will toggle the side window with the notes file.  The notes will dynamically narrow to the relevant part of the file as the user navigates the file tree and will also switch to/from the local org-mode file if applicable.  If there is no note entry for the file, then the message "*No File Note Entry*" will be shown in the side window.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Operations on a single file/directory can be invoked by pressing the *o* key (`f
 | `dired`                     | od  | opens a dired session at the directory at point |
 | `filetree-run-eshell`       | oe  | opens an eshell at the directory at point       |
 | `filetree-run-magit-status` | oms | run magit-status on repo for file/dir at point  |
+|  filetree-create-note       | on  | Create file note from file at point             |
 
 Users can also add their own operations by customizing *filetree-custom-single-operations*.
 ## Marking files
@@ -213,7 +214,7 @@ This package maintains a notes file in the file specified by *filetree-notes-fil
 
 Local project specific notes files can also be used--simply create an empty file in the project directory with the name "*filetree-notes-local.org*" (or whatever name is set by the variable *filetree-relative-notes-filename*).  Files under this directory will use this file for notes instead of the main file.  The file links in the local file will be relative to the project directory.  The main org-mode file will still be used for files without a local org-mode file.
 
-In order to go to the entry for a file (and create an entry if it doesn't exist), use the `filetree-toggle-info-buffer` command.  For example, you can use the following key binding in your .emacs to run the command:
+In order to go to the entry for a file (and create an entry if it doesn't exist from a file buffers), use the `filetree-toggle-info-buffer` command.  For example, you can use the following key binding in your .emacs to run the command:
 ```
 (global-set-key (kbd "C-c <return>") (lambda ()
                                        "Toggle filetree-info-buffer and switch to it if active"
@@ -221,6 +222,14 @@ In order to go to the entry for a file (and create an entry if it doesn't exist)
                                        (filetree-toggle-info-buffer t)))
 ```
 The same command will open and close (after saving) the notes buffer in the side window.
+
+To create a new note from the file at point in the *filetree* buffer or a *dired* buffer, use the command `filetree-create-note`.  If you would like to have the notes update as you navigate through *dired* buffers (as they do in the *filetree* buffer), you can add the following advice call in your `.emacs`:
+```
+(advice-add 'dired-next-line :after
+            (lambda (&rest args)
+              (filetree-update-info-buffer
+               (file-truename (dired-get-file-for-visit)))))
+```
 
 Within the *filetree* buffer, the *i* key will toggle the side window with the notes file.  The notes will dynamically narrow to the relevant part of the file as the user navigates the file tree and will also switch to/from the local org-mode file if applicable.  If there is no note entry for the file, then the message "*No File Note Entry*" will be shown in the side window.
 

--- a/filetree.el
+++ b/filetree.el
@@ -1973,7 +1973,7 @@ If open, save before closing."
    ((equal major-mode 'dired-mode) (file-truename
                                     (let ((file (condition-case nil
                                                     (dired-get-file-for-visit)
-                                                  (error nil))))
+                                                  (error ""))))
                                       (if (file-directory-p file)
                                           (concat file "/")
                                         file))))

--- a/filetree.el
+++ b/filetree.el
@@ -438,7 +438,7 @@ This is used if the file doesn't match any regex in `filetree-filetype-list'."
     (define-key map "q" 'filetree-close-session)
     (define-key map "x" 'filetree-remove-item)
     (define-key map (kbd "<RET>") 'filetree-open-or-narrow)
-    (define-key map (kbd "C-<RET>") 'filetree-open-in-other-window)
+    ;; (define-key map (kbd "C-<RET>") 'filetree-open-in-other-window)
     ;; stack operations
     (define-key map "b" 'filetree-pop-file-list-stack)
     (define-key map "-" 'filetree-diff-with-file-list-stack)
@@ -576,8 +576,8 @@ entry of the list has the following:
   "Helper function to generate setup-children for basic cmds."
   (append
    (filetree--setup-children '(("Quit filetree" filetree-close-session)
-                               ("Remove item" filetree-remove-item :transient t)
-                               ("Open in other win" filetree-open-in-other-window :transient t)))
+                               ("Remove item" filetree-remove-item :transient t)))
+                               ;; ("Open in other win" filetree-open-in-other-window :transient t)))
    ;; special handling because if point on file,
    ;; :transient should be nil and for dir :transient should be t
    (transient--parse-child

--- a/filetree.el
+++ b/filetree.el
@@ -227,7 +227,8 @@ Each entry has:
 (defcustom filetree-custom-single-operations
   '(("d" "open dired on dir at point" dired)
     ("e" "open eshell in dir at point" filetree-run-eshell)
-    ("ms" "magit-status on repo at point" filetree-run-magit-status))
+    ("ms" "magit-status on repo at point" filetree-run-magit-status)
+    ("n" "Create file note from file at point" filetree-create-note))
   "List of custom operations acting on file/dir at point.
 Each entry has:
 - keyboard shortcut under the file operation menu
@@ -437,6 +438,7 @@ This is used if the file doesn't match any regex in `filetree-filetype-list'."
     (define-key map "q" 'filetree-close-session)
     (define-key map "x" 'filetree-remove-item)
     (define-key map (kbd "<RET>") 'filetree-open-or-narrow)
+    (define-key map (kbd "C-<RET>") 'filetree-open-in-other-window)
     ;; stack operations
     (define-key map "b" 'filetree-pop-file-list-stack)
     (define-key map "-" 'filetree-diff-with-file-list-stack)
@@ -574,7 +576,10 @@ entry of the list has the following:
   "Helper function to generate setup-children for basic cmds."
   (append
    (filetree--setup-children '(("Quit filetree" filetree-close-session)
-                               ("Remove item" filetree-remove-item :transient t)))
+                               ("Remove item" filetree-remove-item :transient t)
+                               ("Open in other win" filetree-open-in-other-window :transient t)))
+   ;; special handling because if point on file,
+   ;; :transient should be nil and for dir :transient should be t
    (transient--parse-child
     'filetree-command-help
     '("<RET>" "open/narrow" filetree-open-or-narrow :transient t))))
@@ -1043,6 +1048,21 @@ If FILE-OR-DIR not specified, use file or dir at point."
       (filetree-close-preview-buffer)
       (filetree-close-info-buffer)
       (find-file file-or-dir))))
+
+(defun filetree-open-in-other-window (&optional file-or-dir)
+  "Open file or dired on dir in other window.
+If FILE-OR-DIR not specified, use file or dir at point."
+  (interactive)
+  (filetree-goto-node)
+  (let ((file-or-dir (or file-or-dir (filetree-get-name))))
+    (if (string= "/" (substring file-or-dir -1))
+        ;; open dired on subdir
+        (progn
+          (save-selected-window
+            (dired-other-window (filetree-get-name))))
+      ;; open file
+      (save-selected-window
+        (find-file-other-window file-or-dir)))))
 
 (defun filetree-remove-item (&optional file-or-dir)
   "Remove the file or subdir FILE-OR-DIR from the `filetree-current-file-list'.
@@ -1919,7 +1939,9 @@ If SWITCH-TO-INFO-FLAG is true, then switch to the info window afterwards."
   (interactive)
   (let ((file-for-info-buffer (if (string-equal (buffer-name) filetree-buffer-name)
                                   (filetree-get-name)
-                                nil)))
+                                (if (equal major-mode 'dired-mode)
+                                    (file-truename (dired-get-file-for-visit))
+                                  nil))))
     (if (and (buffer-live-p filetree-info-buffer)
              (window-live-p filetree-info-window))
         (filetree-close-info-buffer)
@@ -1948,59 +1970,88 @@ If open, save before closing."
         (switch-to-buffer filetree-info-buffer)
         (save-buffer)
         (kill-buffer filetree-info-buffer))))
-  
-(defun filetree-update-info-buffer (&optional current-file-name)
+
+(defun filetree-create-note (&optional file-or-dir)
+  "Open note for FILE-OR-DIR if given.
+If file-or-dir not given find file at point from filetree buffer, dired or file buffer,
+and create a new note if one doesn't exist."
+  (interactive)
+  (let ((cur-file
+         (expand-file-name
+          (or file-or-dir
+              (cond
+               ;; dired buffer
+               ((equal major-mode 'dired-mode) (file-truename (dired-get-file-for-visit)))
+               ;; filetree buffer
+               ((equal (buffer-name) filetree-buffer-name) (filetree-get-name))
+               ;; file buffer
+               ((buffer-file-name) (file-name-directory (buffer-file-name))))))))
+    (if (not cur-file)
+        (error "Must be in a file buffer, dired buffer, or filetree buffer"))
+    ;; disable preview buffer first
+    (filetree-close-preview-buffer)
+    (if (and (buffer-live-p filetree-info-buffer)
+             (window-live-p filetree-info-window))
+        (filetree-close-info-buffer))
+    (filetree-toggle-info-buffer t)
+    (filetree-update-info-buffer cur-file t)))
+
+(defun filetree-update-info-buffer (&optional current-file-name create-new-entry-flag)
   "Update info buffer contents to reflect CURRENT-FILE-NAME.
 If CURENT-FILE-NAME not given use 'buffer-file-name'.
-If no entry in info buffer for this file, create new info buffer entry."
+If CREATE-NEW-ENTRY-FLAG is set or there is no entry in info buffer for this file, 
+create new info buffer entry."
   ;; TODO: clean up
-  (let ((filetree-create-new-entry (if current-file-name nil t))
-        (filetree-info-buffer-new nil))
-    (unless current-file-name (setq current-file-name (buffer-file-name)))
-    (unless current-file-name (setq current-file-name "No File Note Entry"))
-    (let ((current-window (selected-window))
-          (local-notes-file nil))
-      (select-window filetree-info-window)
-      (switch-to-buffer filetree-info-buffer)
-      ;;(save-buffer)
-      (setq local-notes-file (filetree-find-notes-file current-file-name))
-      (if local-notes-file
-          (progn
-            (setq filetree-info-buffer-new (find-file-noselect local-notes-file))
-            (setq current-file-name (concat "./"
-                                            (file-relative-name current-file-name
-                                                                (file-name-directory
-                                                                 local-notes-file)))))
-        (setq filetree-info-buffer-new (find-file-noselect filetree-notes-file)))
-      (if (and (not (equal filetree-info-buffer-new filetree-info-buffer))
-               (buffer-live-p filetree-info-buffer))
-          (progn
-            (save-buffer)
-            (kill-buffer filetree-info-buffer)
-            (setq filetree-info-buffer filetree-info-buffer-new)
-            (setq filetree-info-window
-                  (display-buffer-in-side-window filetree-info-buffer
-                                                 '((side . right))))))
-      (select-window filetree-info-window)
-      (switch-to-buffer filetree-info-buffer)
-      (if (get-buffer-window filetree-info-buffer)
-          (let ((search-string (concat "* [[" current-file-name "]")))
-            (widen)
-            (goto-char (point-min))
-            (unless (search-forward search-string nil t)
-              (if filetree-create-new-entry
-                  (progn
-                    (message "creating new entry")
-                    (goto-char (point-max))
-                    (let ((filename (car (last (split-string current-file-name "/") 1))))
-                      (insert "\n" "* [[" current-file-name "][" filename "]]\n")))
-                (unless (search-forward "* [[No File Note Entry]" nil t)
-                  (progn
-                    (message "creating No File Note Entry")
-                    (goto-char (point-max))
-                    (filetree-insert-no-note-entry)))))
-            (org-narrow-to-subtree)))
-      (select-window current-window))))
+  (if (and (buffer-live-p filetree-info-buffer)
+           (window-live-p filetree-info-window))
+      (let ((filetree-create-new-entry (or create-new-entry-flag (if current-file-name nil t)))
+            (filetree-info-buffer-new nil))
+        (unless current-file-name (setq current-file-name (buffer-file-name)))
+        (unless current-file-name (setq current-file-name "No File Note Entry"))
+        (let ((current-window (selected-window))
+              (local-notes-file nil))
+          (select-window filetree-info-window)
+          (switch-to-buffer filetree-info-buffer)
+          ;;(save-buffer)
+          (setq local-notes-file (filetree-find-notes-file current-file-name))
+          (if local-notes-file
+              (progn
+                (setq filetree-info-buffer-new (find-file-noselect local-notes-file))
+                (setq current-file-name (concat "./"
+                                                (file-relative-name current-file-name
+                                                                    (file-name-directory
+                                                                     local-notes-file)))))
+            (setq filetree-info-buffer-new (find-file-noselect filetree-notes-file)))
+          (if (and (not (equal filetree-info-buffer-new filetree-info-buffer))
+                   (buffer-live-p filetree-info-buffer))
+              (progn
+                (save-buffer)
+                (kill-buffer filetree-info-buffer)
+                (setq filetree-info-buffer filetree-info-buffer-new)
+                (setq filetree-info-window
+                      (display-buffer-in-side-window filetree-info-buffer
+                                                     '((side . right))))))
+          (select-window filetree-info-window)
+          (switch-to-buffer filetree-info-buffer)
+          (if (get-buffer-window filetree-info-buffer)
+              (let ((search-string (concat "* [[" current-file-name "]")))
+                (widen)
+                (goto-char (point-min))
+                (unless (search-forward search-string nil t)
+                  (if filetree-create-new-entry
+                      (progn
+                        (message "creating new entry")
+                        (goto-char (point-max))
+                        (let ((filename (car (last (split-string current-file-name "/") 1))))
+                          (insert "\n" "* [[" current-file-name "][" filename "]]\n")))
+                    (unless (search-forward "* [[No File Note Entry]" nil t)
+                      (progn
+                        (message "creating No File Note Entry")
+                        (goto-char (point-max))
+                        (filetree-insert-no-note-entry)))))
+                (org-narrow-to-subtree)
+                (move-end-of-line nil)))
+          (select-window current-window)))))
 
 (defun filetree-insert-no-note-entry ()
   "Insert an entry in info file indicating not file note entry.

--- a/filetree.el
+++ b/filetree.el
@@ -1985,7 +1985,7 @@ and create a new note if one doesn't exist."
                ;; filetree buffer
                ((equal (buffer-name) filetree-buffer-name) (filetree-get-name))
                ;; file buffer
-               ((buffer-file-name) (file-name-directory (buffer-file-name))))))))
+               ((buffer-file-name) (buffer-file-name)))))))
     (if (not cur-file)
         (error "Must be in a file buffer, dired buffer, or filetree buffer"))
     ;; disable preview buffer first
@@ -1994,6 +1994,7 @@ and create a new note if one doesn't exist."
              (window-live-p filetree-info-window))
         (filetree-close-info-buffer))
     (filetree-toggle-info-buffer t)
+    (message cur-file)
     (filetree-update-info-buffer cur-file t)))
 
 (defun filetree-update-info-buffer (&optional current-file-name create-new-entry-flag)


### PR DESCRIPTION
These are changes for the feature request https://github.com/knpatel401/filetree/issues/14, which was to provide the ability to add a new note from either the `filetree` buffer or a `dired` buffer without actually opening the file.